### PR TITLE
Made the R key ALWAYS kill

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -3536,10 +3536,9 @@ class PlayState extends MusicBeatState
 		// RESET = Quick Game Over Screen
 		if (!ClientPrefs.noReset && controls.RESET && canReset && !inCutscene && startedCountdown && !endingSong)
 		{
-			health = 0;
+			doDeathCheck(true);
 			trace("RESET = True");
 		}
-		doDeathCheck();
 
 		if (unspawnNotes[0] != null)
 		{


### PR DESCRIPTION
Removed the lazy "set to 0" for a proper death check (Because ShadowMario is too lazy to change one line of code :/ )

The code need to be tested since I cannot build the game, but it's such a small thing that it doesn't require hours of testing